### PR TITLE
Feat : added stale issue and PR workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,68 @@
+name: Mark stale issues and pull requests
+
+on:
+  schedule:
+    - cron: '0 0 * * 0'  # Runs every Sunday at midnight
+
+permissions:
+  issues: write
+  pull-requests: write  
+  
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/stale@v8
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+        # Message to comment on stale issues.
+        stale-issue-message: | 
+          Hello! :wave: 
+
+          This issue has been automatically marked as stale due to inactivity :sleeping:
+
+          It will be closed in 180 days if no further activity occurs. To keep it active, please add a comment with more details.
+
+          There can be many reasons why a specific issue has no activity. The most probable cause is a lack of time, not a lack of interest.
+
+          Let us figure out together how to push this issue forward. Connect with us through our slack channel : https://json-schema.org/slack
+
+          Thank you for your patience :heart:
+        
+        # Message to comment on stale pull requests.
+        stale-pr-message: |
+          Hello! :wave: 
+
+          This pull request has been automatically marked as stale due to inactivity :sleeping:
+
+          It will be closed in 180 days if no further activity occurs. To keep it active, please add a comment with more details.
+
+          There can be many reasons why a specific pull request has no activity. The most probable cause is a lack of time, not a lack of interest.
+
+          Let us figure out together how to push this pull request forward. Connect with us through our slack channel : https://json-schema.org/slack
+
+          Thank you for your patience :heart:
+        
+        # Message to comment on issues that are about to be closed.
+        close-issue-message: 'This issue did not get any activity in the past 180 days and thus has been closed. Please check if the main branch has fixed it. Please, create a new issue if the issue is not fixed.'
+         
+        # Message to comment on pull requests that are about to be closed.
+        close-pr-message: 'This pull request did not get any activity in the past 180 days and thus has been closed.'
+           
+        # Labels to add to stale issues and pull requests.
+        stale-issue-label: 'Status: Stale'
+        stale-pr-label: 'Status: Stale'
+        
+        # Number of days of inactivity before an issue/PR is marked as stale.
+        days-before-stale: 30
+       
+        # Number of days of inactivity before an issue/PR is closed.
+        days-before-close: 180
+        
+        # Remove the stale label when the issue/PR is updated.
+        remove-stale-when-updated: true
+       
+        # Exempt labels to ignore when checking for stale issues/PRs.
+        exempt-pr-labels: 'Status: On Hold,Status: Blocked'
+        exempt-issue-labels: 'Status: On Hold,Status: Blocked'


### PR DESCRIPTION
<!-- In order to keep off topic discussion to a minimum, it helps if the "work to be done" is already agreed on. -->
<!-- Ideally, a GitHub Issue with the label `Status: Consensus` will have been concluded, and linked to in this PR. -->
<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**

Feature : Added stale Issue and Pull Request

**Issue Number:**
<!-- Pick one of the below options.  Please remove those which don't apply. -->
-  Closes #58 

**Screenshots/videos:**

<!--Add screenshots or videos wherever possible.-->

**If relevant, did you update the documentation?**

<!--Add link to it-->

**Summary**

- This workflow will mark stale the issue and pull-request after 30 days if there is no activity. It will closes the issue and pull-request after 180 days if there is no further activity. 
- This will helps us to manage issue and pull-request in more better way.
- This will also help us to identify which issue or pull request is important.

**Does this PR introduce a breaking change?**
- No