### PR TITLE
🐛 Fix: Update Copyright Year to © 2025 (#96)

### DIFF
--- a/settings.yml
+++ b/settings.yml
@@ -139,8 +139,7 @@ footer:
     twitter: "https://twitter.com/jsonschema"
     youtube: "https://www.youtube.com/@JSONSchemaOrgOfficial"
   logo: "https://json-schema.org/img/logos/logo-white.svg"
-  text: "Copyright © 2024 JSON Schema. All rights reserved."
-
+  text: "Copyright © 2025 JSON Schema. All rights reserved." 
 # Grid items size (optional)
 #
 # Defines the preferred size of the landscape items in the grid mode. When the


### PR DESCRIPTION
What kind of change does this PR introduce?
🐛 Bugfix

Issue Number:
Closes #96

**Screenshots/videos:**

Previous : ![prev-year](https://github.com/user-attachments/assets/15cd2f7c-5bd4-432b-a72c-a1f0628dcfd7)

Updated : ![updated year](https://github.com/user-attachments/assets/b71729ca-cf62-4a6c-8b9f-13fe085d6f69)

If relevant, did you update the documentation?
N/A

Summary:
This PR addresses the issue by updating the copyright year from © 2024 to © 2025, ensuring that the repository reflects the current year and remains compliant.

Does this PR introduce a breaking change?
No.