### PR TITLE
Resolve the markdown badge 

### DIFF
--- a/settings.yml
+++ b/settings.yml
@@ -9,7 +9,7 @@
 #
 # foundation: <FOUNDATION_NAME>
 #
-foundation: JSON Schema
+foundation: JSON_Schema
 
 # Url (required)
 #


### PR DESCRIPTION
**What kind of change does this PR introduce?**
 bugfix

**Issue Number:**
-  Closes #111 


**Screenshots/videos:**
[Screencast from 2025-04-12 16-23-54.webm](https://github.com/user-attachments/assets/1b821519-0027-4545-94e3-1452ef35ef23)


**Summary**
In setting it is mentioned that foundation name should be  in this convention **foundation: <FOUNDATION_NAME>** but it was written as **foundation : JSON Schema**. That's is the reasons it is rending invalid link and not showing the badge. 

**Does this PR introduce a breaking change?**
Nope, I test it an working fine.