### PR TITLE
Add Model Context Protocol to the Landscape

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -23,6 +23,12 @@ categories:
             twitter: https://twitter.com/OpenApiSpec
             project_org: https://github.com/oai
             description: The world's most widely used API description standard. The OpenAPI Specification provides a formal standard for describing HTTP APIs.
+          - name: Model Context Protocol
+            homepage_url: https://modelcontextprotocol.io/
+            documentation_url: https://modelcontextprotocol.io/specification/2026-07-28/basic#json-schema-usage
+            logo: model-context-protocol.svg
+            project_org: https://github.com/modelcontextprotocol
+            description: An open protocol for connecting AI applications to external systems. MCP uses JSON Schema for validation throughout the protocol and requires support for JSON Schema 2020-12 by default.
           - name: Serverless Workflow
             homepage_url: https://serverlessworkflow.io/
             logo: serverless-workflow.svg

--- a/logos/model-context-protocol.svg
+++ b/logos/model-context-protocol.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 160" role="img" aria-labelledby="title">
+  <title id="title">Model Context Protocol</title>
+  <rect width="320" height="160" rx="24" fill="#111827"/>
+  <path d="M52 108 100 60c7-7 19-7 26 0s7 19 0 26l-36 36" fill="none" stroke="#fff" stroke-linecap="round" stroke-width="10"/>
+  <path d="m88 108 36-36c7-7 19-7 26 0s7 19 0 26l-44 44" fill="none" stroke="#fff" stroke-linecap="round" stroke-width="10"/>
+  <text x="176" y="96" fill="#fff" font-family="Arial, sans-serif" font-size="48" font-weight="700">MCP</text>
+</svg>


### PR DESCRIPTION
## Summary

- Add the Model Context Protocol (MCP) to the Standards section of the JSON Schema Landscape.
- Link directly to MCP’s JSON Schema usage specification.
- Add an MCP logo asset.

## Evidence

MCP uses JSON Schema for validation throughout the protocol and requires implementations to support JSON Schema 2020-12 by default:

https://modelcontextprotocol.io/specification/2026-07-28/basic#json-schema-usage